### PR TITLE
Created install script for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ sudo ./installer.sh
 ### Execution
 Excecute Pinguino-IDE with  
 ```shell
-python pinguino.py
+pinguino
 ```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,36 @@
 # pinguino-installers
 Installation scripts for the Pinguino IDE
 
-<b>GNU/Linux</b>
-<hr>
-<p><b>installer.sh</b>  : Basic shell script to install the Pinguino IDE</p>
-<p><b>zinstaller.sh</b> : Graphic (based on GTK+/Zenity) shell script to install the Pinguino IDE</p>
-<p>Make the script executable with : <b>sudo chmod +x installer.sh</b> or <b>sudo chmod +x zinstaller.sh</b></p>
-<p>Launch the script with : <b>sudo ./installer.sh</b> or <b>sudo ./zinstaller.sh</b></p>
-<b>Windows</b>
-<hr>
-<p>See https://github.com/MefhigosetH/pinguino-nsi-installer</p>
-<b>Mac OS X</b>
-<hr>
-<p>TODO</p>
+## GNU/Linux
+`installer.sh`: Basic shell script to install the Pinguino IDE
+
+`zinstaller.sh`: Graphic (based on GTK+/Zenity) shell script to install the Pinguino IDE
+
+Make the script executable with:
+`sudo chmod +x installer.sh` or `sudo chmod +x zinstaller.sh`
+
+Launch the script with: `sudo ./installer.sh` or `sudo ./zinstaller.sh`
+
+## Windows
+See [https://github.com/MefhigosetH/pinguino-nsi-installer](https://github.com/MefhigosetH/pinguino-nsi-installer)
+
+## Mac OS X
+
+### Requirements
+- Xcode
+- developer tools
+
+### Installation
+Make the script executable with:
+```shell
+sudo chmod +x installer.sh
+```
+Launch the script with:
+```shell
+sudo ./installer.sh
+```
+### Execution
+Excecute Pinguino-IDE with  
+```shell
+python pinguino.py
+```

--- a/mac/installer.sh
+++ b/mac/installer.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Check if xcode is installed
+if [ `xcode-select -p` = "/Applications/Xcode.app/Contents/Developer" ] ; then
+    echo "Xcode Installed..."
+else
+    echo "ERROR: No Xcode Instalation found.
+Please install Xcode and continue with this script"
+    exit -1
+fi
+
+if [ `git --version` = "-bash: git: command not found" ] ; then
+    echo "Installing developer tools..."
+    xcode-select --install
+else
+    echo "Git installed..."
+fi
+
+# Check if homebrew is installed
+if [ `brew --version` = "-bash: brew: command not found" ] ; then
+    echo "Installing homebrew tools..."
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+else
+    echo "Homebrew installed: updating"
+    brew update
+fi
+# TODO: Check for brew doctor messages
+
+brew install python
+brew install pyside sdcc
+
+pip install gitpython hgapi beautifulsoup4 pyusb
+
+[ ! -d ~/.pinguino ] && mkdir -pv ~/.pinguino
+[ ! -d /usr/share/pinguino-11 ] && sudo mkdir -pv /usr/share/pinguino-11
+
+git clone https://github.com/PinguinoIDE/pinguino-ide.git ~/.pinguino
+git clone https://github.com/PinguinoIDE/pinguino-libraries.git ~/.pinguino
+
+cd ~/.pinguino
+
+sudo ln -sfv /p8 /usr/share/pinguino-11/
+sudo ln -sfv ~/.pinguino/p8/bin/sdcc /usr/bin/sdcc
+
+#Change paths.cfg
+#install_path = ~/.pinguino
+#user_path = ~/.pinguino

--- a/mac/installer.sh
+++ b/mac/installer.sh
@@ -23,7 +23,14 @@ else
     echo "Homebrew installed: updating"
     brew update
 fi
-# TODO: Check for brew doctor messages
+
+# Check for brew doctor messages
+if [ `brew doctor` = "Your system is ready to brew." ] ; then
+    echo "Homebrew is up and ready... "
+else
+    echo "Homebrew seems to be sick run brew doctor and fix your problems, then come back."
+    exit 2
+fi
 
 brew install python
 brew install pyside sdcc
@@ -40,7 +47,4 @@ cd ~/.pinguino
 
 sudo ln -sfv /p8 /usr/share/pinguino-11/
 sudo ln -sfv ~/.pinguino/p8/bin/sdcc /usr/bin/sdcc
-
-#Change paths.cfg
-#install_path = ~/.pinguino
-#user_path = ~/.pinguino
+sudo ln -sfv ~/.pinguino/pinguino.py /usr/local/bin/pinguino

--- a/mac/uninstaller.sh
+++ b/mac/uninstaller.sh
@@ -1,0 +1,1 @@
+rm -rf ~/.pinguino /usr/share/pinguino-11 /usr/bin/sdcc

--- a/mac/uninstaller.sh
+++ b/mac/uninstaller.sh
@@ -1,1 +1,1 @@
-rm -rf ~/.pinguino /usr/share/pinguino-11 /usr/bin/sdcc
+rm -rf ~/.pinguino /usr/share/pinguino-11 /usr/bin/sdcc /usr/local/bin/pinguino


### PR DESCRIPTION
Hey, I've been installing pinguino-IDE this way on several computers and thought you might use the script. I've also updated the readme to github markdown.

The script checks for xcode, homebrew, git, and python and installs the necessary libraries, then makes a soft link to the /usr/local/bin path, so pinguino can be run from anythere.
