### PR TITLE
cp instead of ln and link hb sdcc

### DIFF
--- a/mac/installer.sh
+++ b/mac/installer.sh
@@ -59,8 +59,8 @@ rm master.zip
 cp -a ~/.pinguino/pinguino-libraries-master/p* ~/.pinguino
 
 # Link the binaries to /usr folder
-sudo ln -sfv /p8 /usr/share/pinguino-11/
-sudo ln -sfv ~/.pinguino/p8/bin/sdcc /usr/bin/sdcc
+sudo cp -aR p8 /usr/share/pinguino-11/
+sudo ln -sfv /usr/local/bin/sdcc /usr/bin/sdcc
 # Check if alias exits in ~/.bash_profile
 if grep -q "alias pinguino" ~/.bash_profile|wc -l
 then


### PR DESCRIPTION
_Problem:_ Some mac users had trouble with the soft linking of p8 folder 
_Fix:_ Do a hard copy of p8.
_Problem:_ Pinguino-IDE looks for sdcc in /usr/bin even if there is another one in the path.
_Fix:_ Homebrew sdcc linked to the binary folder in usr share.
