### PR TITLE
Jimgregory patch 1

### DIFF
--- a/linux/installer.sh
+++ b/linux/installer.sh
@@ -108,6 +108,9 @@ log $NORMAL ---------------------------------------------------------------
 if [ `uname -m` == "armv6l" ]; then
     ARCH=RPi
     log $NORMAL "Host is a Raspberry Pi."
+if [ `uname -m` == "armv7l" ]; then
+    ARCH=RPi
+    log $NORMAL "Host is a Raspberry Pi 2."
 elif [ `uname -m` == "x86_64" ]; then
     ARCH=64
     log $NORMAL "Host is a ${ARCH}-bit GNU/Linux."

--- a/linux/zinstaller.sh
+++ b/linux/zinstaller.sh
@@ -51,6 +51,9 @@ function install {
 if [ `uname -m` == "armv6l" ]; then
     ARCH=RPi
     ARCHTXT="Raspberry Pi"
+elif [ `uname -m` == "armv7l" ]; then
+    ARCH=RPi
+    ARCHTXT="Raspberry Pi 2"
 elif [ `uname -m` == "x86_64" ]; then
     ARCH=64
     ARCHTXT="${ARCH}-bit GNU/Linux."


### PR DESCRIPTION
original installer identified only original raspberry pi models (armv6 architecture).  This fix adds support for raspberry pi 2 (armv7).
