### PR TITLE
Source bash_profile from installer

### DIFF
--- a/mac/installer.sh
+++ b/mac/installer.sh
@@ -67,5 +67,6 @@ then
     echo "Instalation successful, you can run pinguino-IDE with command 'pinguino'."
 else
     echo "alias pinguino='python ~/.pinguino/pinguino.py'" >> ~/.bash_profile
+    source ~/.bash_profile
     echo "Instalation successful, you can run pinguino-IDE with command 'pinguino'."
 fi


### PR DESCRIPTION
Users running the installer step by step don't restart the console, and think the program isn't installed. To solve that a line sourcing the bash_profile has been added.
